### PR TITLE
Limit the group name to 32 characters to avoid max index key length p…

### DIFF
--- a/src/database/migrations/2016_11_25_145037_create_groups_table.php
+++ b/src/database/migrations/2016_11_25_145037_create_groups_table.php
@@ -15,7 +15,7 @@ class CreateGroupsTable extends Migration
     {
         Schema::create('groups', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name');
+            $table->string('name', 32);
             $table->string('color')->nullable();
             $table->string('type');
             $table->timestamps();


### PR DESCRIPTION
Limits the group name to 32 characters.
Avoids max key index length (1000 char) problems during migration