### PR TITLE
This fixes the publish path from core to build.core.

### DIFF
--- a/src/Build/Core/ServiceProvider.php
+++ b/src/Build/Core/ServiceProvider.php
@@ -45,7 +45,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             ], 'migrations');
 
             $this->publishes([
-                __DIR__ . '/../../resources/views' => resource_path('views/vendor/core')
+                __DIR__ . '/../../resources/views' => resource_path('views/vendor/build.core')
             ], 'views');
 
             $this->publishes([


### PR DESCRIPTION
When publishing views to the app, core tries to publish them to /core
instead of build.core resulting in non-discoverable views in the app folder.

(temporary fix while waiting for a better view namespacing solution)