### PR TITLE
add for= to bauhaus inputs so errors can be rendered correctly

### DIFF
--- a/src/resources/views/components/bauhaus/input/checkbox.blade.php
+++ b/src/resources/views/components/bauhaus/input/checkbox.blade.php
@@ -1,4 +1,4 @@
-<div class="row{{ $errors->has($node->name) ? ' error' : '' }}">
+<div class="row{{ $errors->has($node->name) ? ' error' : '' }}" for="{{ $node->get('name') }}">
 	<div class="small-12 medium-6 medium-push-3">
 		<label>
 			<input type="hidden" name="{{ $node->get('name') }}" value="0">

--- a/src/resources/views/components/bauhaus/input/email.blade.php
+++ b/src/resources/views/components/bauhaus/input/email.blade.php
@@ -1,4 +1,4 @@
-<div class="row {{ $errors->has($node->get('name')) ? 'error' : '' }}">
+<div class="row {{ $errors->has($node->get('name')) ? 'error' : '' }}" for="{{ $node->get('name') }}">
 	<div class="small-12 medium-4">
 		<label for="f-{{ $node->get('name') }}" class="text-right middle">
 			{{ $node->get('label') }}

--- a/src/resources/views/components/bauhaus/input/groups.blade.php
+++ b/src/resources/views/components/bauhaus/input/groups.blade.php
@@ -1,4 +1,4 @@
-<div class="row {{ $errors->has($node->name) ? 'error' : '' }}">
+<div class="row {{ $errors->has($node->name) ? 'error' : '' }}" for="{{ $node->name }}">
     <div class="small-12 medium-6 medium-push-3">
         <label for="f-{{ $node->name }}">
             {{ $node->label }}

--- a/src/resources/views/components/bauhaus/input/label.blade.php
+++ b/src/resources/views/components/bauhaus/input/label.blade.php
@@ -1,4 +1,4 @@
-<div class="row {{ $errors->has($node->get('name')) ? 'error' : '' }}">
+<div class="row {{ $errors->has($node->get('name')) ? 'error' : '' }}" for="{{ $node->get('name') }}">
 	<div class="small-12 medium-6 medium-push-3">
 		<label for="f-{{ $node->get('name') }}" class="text-right middle">
 			{{ $node->get('label') }}

--- a/src/resources/views/components/bauhaus/input/password.blade.php
+++ b/src/resources/views/components/bauhaus/input/password.blade.php
@@ -1,4 +1,4 @@
-<div class="row {{ $errors->has($node->get('name')) ? 'error' : '' }}">
+<div class="row {{ $errors->has($node->get('name')) ? 'error' : '' }}" for="{{ $node->get('name') }}">
 	<div class="small-12 medium-6 medium-push-3">
 		<label for="f-{{ $node->get('name') }}" class="text-right middle">
 			{{ $node->get('label') }}

--- a/src/resources/views/components/bauhaus/input/select.blade.php
+++ b/src/resources/views/components/bauhaus/input/select.blade.php
@@ -1,4 +1,4 @@
-<div class="row {{ $errors->has($node->get('name')) ? 'error' : '' }}">
+<div class="row {{ $errors->has($node->get('name')) ? 'error' : '' }}" for="{{ $node->get('name') }}">
 	<div class="small-12 medium-6 medium-push-3">
 		<label for="f-{{ $node->get('name') }}">
 			{{ $node->get('label') }}

--- a/src/resources/views/components/bauhaus/input/textarea.blade.php
+++ b/src/resources/views/components/bauhaus/input/textarea.blade.php
@@ -1,4 +1,4 @@
-<div class="row {{ $errors->has($node->get('name')) ? 'error' : '' }}">
+<div class="row {{ $errors->has($node->get('name')) ? 'error' : '' }}" for="{{ $node->get('name') }}">
 	<div class="small-12 medium-6 medium-push-3">
 		<label for="{{ $node->get('name') }}">
 			{{ $node->get('label') }}


### PR DESCRIPTION
Errors for some fields such as input.select were not rendered when using the Sidebar.resource method

the for= attribute is needed to find the correct error in the form