### PR TITLE
Feature/2017 04 20 add image formatter to assets

### DIFF
--- a/src/Build/Core/Eloquent/Models/Asset.php
+++ b/src/Build/Core/Eloquent/Models/Asset.php
@@ -16,15 +16,20 @@ use Build\Core\Eloquent\Traits\Groupable;
 use Build\Core\Support\Mime;
 use Build\Core\Support\System;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
 use Intervention\Image\Constraint;
 use Intervention\Image\Facades\Image;
+use Build\Core\Support\ImageFormatter;
 use Ramsey\Uuid\Uuid;
 
 class Asset extends Model
 {
 
     use Groupable;
+    
+    /**
+     * @var ImageFormatter
+     */
+    private $_formatter;
 
     /**
      * Mass-assignment protection.
@@ -165,6 +170,18 @@ class Asset extends Model
     protected function getQualifiedFilename(UploadedFile $file = null)
     {
         return $this->uuid . '.' . ($file ? $file->getClientOriginalExtension() : $this->extension );
+    }
+    
+    /**
+     * Gets the imageformatter
+     * 
+     * @return ImageFormatter
+     */
+    public function formatter() {
+        if (!$this->_formatter) {
+            $this->_formatter = new ImageFormatter($this);
+        }
+        return $this->_formatter;
     }
 
     /**

--- a/src/Build/Core/Http/Controllers/Assets/FrontendController.php
+++ b/src/Build/Core/Http/Controllers/Assets/FrontendController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Build\Core\Http\Controllers\Assets;
+
+use Build\Core\Http\Controller;
+use Illuminate\Http\Request;
+use Build\Core\Eloquent\Models\Asset;
+
+class FrontendController extends Controller {
+    
+    /**
+     * Format the Image input request
+     * 
+     * @param Request $request
+     * @param string $uuid The assets Uuid
+     * @param string $format The format modifiers
+     * @return mixed Return the image with all the modifiers applied
+     */
+    public function formatMedia(Request $request, $uuid, $format = null)
+    {
+        if ( !($asset = Asset::where('uuid',$uuid)->first()) ) {
+            return response('File not found', 404);
+        }
+        
+        return $asset->formatter()->parse($format)->response();
+    }
+    
+}

--- a/src/Build/Core/Support/ImageFormatter.php
+++ b/src/Build/Core/Support/ImageFormatter.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Build\Core\Support;
+
+use Illuminate\Support\Collection;
+use Build\Core\Eloquent\Models\Asset;
+use Intervention\Image\ImageManagerStatic as Image;
+use Closure;
+/**
+ * Intervention Image Formatter support class
+ */
+class ImageFormatter
+{
+
+    private $modifications = null;
+
+    /**
+     *
+     * @var Asset
+     */
+    private $asset;
+
+    /**
+     * Create from Media Asset
+     * 
+     * @param Asset $asset
+     */
+    public function __construct(Asset $asset = null)
+    {
+        $this->modifications = Collection::make();
+        $this->asset = $asset;
+    }
+
+    /**
+     * Retrieve the image modifier url
+     * 
+     * @return string
+     */
+    public function url()
+    {
+        $formats = [];
+
+        foreach ($this->modifications as $modification) {
+            $formats[] = $this->formatModification($modification);
+        }
+
+        if (empty($formats)) {
+            return $this->asset->url;
+        } else {
+            return route('assets.frontend.formatted', [
+                'format' => implode('/', $formats),
+                'uuid' => $this->asset->uuid,
+            ]);
+        }
+    }
+
+    /**
+     * Parse the modifications
+     * 
+     * @param string $unparsed The modifications to parse
+     * @return \Build\Media\Support\ImageFormatter
+     */
+    public function parse($unparsed)
+    {
+        $this->modifications = Collection::make();
+
+        if (empty($unparsed)) {
+            return $this;
+        }
+
+        $rules = Collection::make(explode('/', $unparsed));
+
+        while ($rules->count()) {
+            $command = $rules->shift();
+            $args = explode('x', $rules->shift());
+
+            $this->modifications->push(Collection::make(array_merge([$command], $args)));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the media asset
+     * 
+     * @param Asset $asset The Media Asset
+     * @return \Build\Media\Support\ImageFormatter
+     */
+    public function asset(Asset $asset = null)
+    {
+        if (!$asset) {
+            return $this->asset;
+        }
+
+        $this->asset = $asset;
+
+        return $this;
+    }
+
+    /**
+     * Format the modification command
+     * 
+     * @param array $modification The modification command including arguments as an array
+     * @return string The formatted modification as a string
+     */
+    public function formatModification($modification)
+    {
+        $all = Collection::make($modification);
+
+        $format = $all->shift();
+        $things = '';
+
+        while ($thing = $all->shift()) {
+            $things[] = $thing;
+        }
+
+        if (empty($things)) {
+            return $format;
+        }
+
+        $format .= '/' . implode('x', $things);
+
+        return $format;
+    }
+    
+    public function cache( Closure $closure ) {
+        if (!class_exists('Intervention\\Image\\ImageCache')) {
+            
+            $image = Image::make($this->asset->path);
+            $this->applyModifications($image);
+            
+            return $image;
+        }
+        
+        return Image::cache(function ($image) {
+                $image->make($this->asset->path);
+                $this->applyModifications($image);
+            }, 10, true);
+    }
+
+    /**
+     * Return the cached response in the given format
+     * 
+     * @return mixed The raw Image response
+     */
+    public function response($format = null, $quality = null)
+    {
+        return $this->cache(function ($image) {
+                $image->make($this->asset->path);
+                $this->applyModifications($image);
+            }, 10, true)->response($format, $quality);
+    }
+    
+    private function modifyMaxCommand(&$image, &$command, &$args) {
+        $before = 'resize';
+        $beforeArgs = $args;
+
+        array_push($beforeArgs, function ($constraint) {
+            $constraint->aspectRatio();
+        });
+
+        call_user_func_array([$image, $before], $beforeArgs);
+
+        $command = 'resizecanvas';
+    }
+
+    /**
+     * Applies all the modifications to the Image Resource
+     * 
+     * @param mixed $image
+     * @return \Build\Media\Support\ImageFormatter
+     */
+    private function applyModifications($image)
+    {
+
+        foreach ($this->modifications as $modification) {
+            $all = Collection::make($modification);
+            $command = $all->shift();
+            $args = $all->toArray();
+            
+            if (method_exists($this, 'modify'. ucwords($command).'Command')) {
+                call_user_func_array([$this, 'modify'. ucwords($command).'Command'], [&$image, &$command, &$args]);
+            }
+            
+            call_user_func_array([$image, $command], $args);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Call the image modification methods and buffer them
+     * 
+     * @param string $name The Image modifier Method name
+     * @param array $arguments The modifier attributes
+     * @return \Build\Media\Support\ImageFormatter
+     * @throws \Exception
+     */
+    public function __call($name, $arguments)
+    {
+        $this->modifications->push(Collection::make(array_merge([$name], $arguments)));
+        return $this;
+    }
+
+}

--- a/src/Build/Core/Support/ImageFormatter.php
+++ b/src/Build/Core/Support/ImageFormatter.php
@@ -161,7 +161,7 @@ class ImageFormatter
 
         call_user_func_array([$image, $before], $beforeArgs);
 
-        $command = 'resizecanvas';
+        $command = 'resizeCanvas';
     }
 
     /**

--- a/src/routes/frontend.php
+++ b/src/routes/frontend.php
@@ -9,4 +9,5 @@
  * file that was distributed with this source code.
  */
 
-Route::get('css/colors.css', 'ColorsController@render');
+require __DIR__ . '/frontend/assets.php';
+require __DIR__ . '/frontend/colors.php';

--- a/src/routes/frontend/assets.php
+++ b/src/routes/frontend/assets.php
@@ -1,0 +1,16 @@
+<?php
+
+$parameters = [
+    'namespace' => Assets::class,
+    'prefix' => 'media'
+];
+
+Route::group($parameters, function () {
+    
+    Route::get('{uuid}/format/{format}', [
+            'as' => 'assets.frontend.formatted',
+            'uses' => 'FrontendController@formatMedia'
+        ])
+        ->where('format', '(.*)');
+    
+});

--- a/src/routes/frontend/colors.php
+++ b/src/routes/frontend/colors.php
@@ -1,0 +1,3 @@
+<?php
+
+Route::get('css/colors.css', 'ColorsController@render');


### PR DESCRIPTION
Adds the old imageformatter back to the assets

So you can do $asset->formatter()->resize(100,100)->greyscale()

Added a new ->max(100,300) method so images can be resized with aspect ratio and then scaled to exact that size.