### PR TITLE
Feature/2017 06 09 add vuedata to vue app

### DIFF
--- a/src/resources/assets/js/core.js
+++ b/src/resources/assets/js/core.js
@@ -21,9 +21,7 @@ Vue.component('input-asset', InputAsset);
 Vue.component('asset-container', AssetContainer);
 Vue.component('asset-picker', AssetPicker);
 
-window.vuedata = {
-    build: window.build
-};
+window.vuedata = window.vuedata || {};
 
 $( window ).load( function () {
     

--- a/src/resources/assets/js/core.js
+++ b/src/resources/assets/js/core.js
@@ -21,10 +21,17 @@ Vue.component('input-asset', InputAsset);
 Vue.component('asset-container', AssetContainer);
 Vue.component('asset-picker', AssetPicker);
 
+window.vuedata = {
+    build: window.build
+};
+
 $( window ).load( function () {
     
     const app = new Vue({
-        el: '#vue-wrapper'
+        el: '#vue-wrapper',
+        data: {
+            vuedata: window.vuedata
+        }
     });
     
     window.app = app;


### PR DESCRIPTION
Vue does not allow binding of outside variables.
This update makes it possible.

So you can do things like this:

<script>
Object.assign(window.vuedata,{
something: "this is something",
grabTitle: function () {
return "Hello world";
}
});
</script>

<data-component v-bind:something="vuedata.something" v-if="vuedata.grabTitle" v-bind:title="vuedata.grabTitle()"/>

Or you can bind in the "correct" way:

window.app.$set(window.vuedata,"something","this is something");
