### PR TITLE
Bugfix/159434435 users cannot be reassigned to another role

### DIFF
--- a/src/Build/Core/Http/Controllers/UsersController.php
+++ b/src/Build/Core/Http/Controllers/UsersController.php
@@ -153,7 +153,14 @@ class UsersController extends Controller
         foreach ($roles as $website => $role) {
             $website = $website ?: null;
 
+            // Role has been unset
             if (! $role) {
+                
+                // Remove the currently assigned role
+                if ( ( $revoke = $user->getRole($website)) ) {
+                    $user->removeRole($revoke->id, $website);
+                }
+                
                 continue;
             }
 

--- a/src/Build/Core/Http/Entities/UserEntity.php
+++ b/src/Build/Core/Http/Entities/UserEntity.php
@@ -151,16 +151,18 @@ class UserEntity extends Manager
                 ]);
 
                 $form->add('input.divider');
+                
+                $globalRole = $query->getRole(null);
 
                 $form->add('input.select', [
                     'name' => 'role[0]',
                     'label' => 'Global',
                     'options' => Role::pluck('id', 'id')->toArray(),
-                    'selected' => auth()->user()->getRole(null)->id
+                    'selected' => $globalRole ? $globalRole->id : 9000
                 ]);
-
+                
                 foreach (Website::all() as $website) {
-                    $role = auth()->user()->getRole($website->getKey());
+                    $role = $query->getRole($website->getKey());
 
                     if ($role) {
                         $role = $role->getKey();


### PR DESCRIPTION
The roles displayed in the user-roles screen did not reflect the roles of the selected user ; however reflected the roles of the logged-in user.

Also ; Assigned roles were never revoked when being unselected.

This fixes the problems outlined above