### PR TITLE
Adds root_url to config

### DIFF
--- a/src/resources/views/components/layout/header.blade.php
+++ b/src/resources/views/components/layout/header.blade.php
@@ -17,6 +17,7 @@
     <script>
         var config = {
             debug: '{{ config('app.debug') }}',
+            root_url: '{{ url('/') }}',
             base_url: '{{ url(config('build.core.uri')) }}',
             csrf_token: '{{ csrf_token() }}'
         };


### PR DESCRIPTION
Added root_url:
config.root_url = {{ url('/') }}

Usefull when using a directory alias configuration in your server configuration.

Scripts using '/<resourceurl>' should use config.root_url+'/<resourceurl>' instead