### PR TITLE
Hotfix/172035392 bug duplicate language entry

### DIFF
--- a/src/Build/Core/Http/Controllers/Languages/IndexController.php
+++ b/src/Build/Core/Http/Controllers/Languages/IndexController.php
@@ -30,10 +30,12 @@ class IndexController extends Controller
         $this->authorize('index-language');
 
         if (auth()->user()->can('edit-language')) {
-            $languages = Language::all();
+            $q = Language::query();
         } else {
-            $languages = Language::byWebsite()->get();
+            $q = Language::byWebsite();
         }
+        
+        $languages = request('all',0) ? $q->get():$q->where('is_active',1)->get();
 
         return entity(LanguageEntity::class, 'index')
             ->setQuery($languages)

--- a/src/Build/Core/Http/Entities/Language/EntryEntity.php
+++ b/src/Build/Core/Http/Entities/Language/EntryEntity.php
@@ -31,7 +31,7 @@ class EntryEntity extends Manager
             ->add('navigation.button', [
                 'to' => route('admin.languages.entries.create', $language->getKey()),
                 'label' => 'Add a new entry',
-                'style' => 'button--success'
+                'style' => 'success'
             ]);
 
         $mapper
@@ -83,10 +83,13 @@ class EntryEntity extends Manager
 
                 $form->action(route('admin.languages.entries.store', request()->route('language')));
 
+                // Only list the items that we do not already have entries for
                 $form->add('input.select', [
                     'name' => 'dictionary_id',
                     'label' => 'Dictionary entry',
-                    'options' => Dictionary::pluck('label', 'id')
+                    'options' => Dictionary::whereDoesntHave('entries', function ($q) {
+                        $q->where('language_id', request()->route('language'));
+                    })->pluck('label', 'id')
                 ]);
 
                 $form->add('input.textarea', [

--- a/src/Build/Core/Http/Entities/LanguageEntity.php
+++ b/src/Build/Core/Http/Entities/LanguageEntity.php
@@ -22,6 +22,20 @@ class LanguageEntity extends Manager
     {
         $heading = (new Heading)->title('Languages');
 
+        if (request()->get('all',0)) {
+            $heading->add('navigation.button', [
+                'to' => route('admin.languages.index'),
+                'label' => 'Show Active',
+                'style' => 'selected'
+            ]);
+        } else {
+            $heading->add('navigation.button', [
+                'to' => route('admin.languages.index', ['all' => 1]),
+                'label' => 'Show all',
+                'style' => 'selected'
+            ]);
+        }
+
         if (auth()->user()->can('create-language')) {
             $heading->add('navigation.button', [
                 'to' => route('admin.languages.dictionary.index'),
@@ -31,7 +45,7 @@ class LanguageEntity extends Manager
             $heading->add('navigation.button', [
                 'to' => route('admin.languages.create'),
                 'label' => 'Create a new language',
-                'style' => 'button--success'
+                'style' => 'success'
             ]);
         }
 

--- a/src/Build/Core/Http/Requests/Language/DictionaryRequest.php
+++ b/src/Build/Core/Http/Requests/Language/DictionaryRequest.php
@@ -31,8 +31,18 @@ class DictionaryRequest extends \Illuminate\Foundation\Http\FormRequest
      */
     public function rules()
     {
-        return [
-            'label' => 'required'
-        ];
+        switch ($this->getMethod()) {
+            case 'PUT':
+            case 'PATCH':
+                $dictionary = $this->route('dictionary');
+                 return [
+                    'label' => 'required|unique:language_dictionaries,label,'.$dictionary->id
+                ];
+            default:
+                return [
+                    'label' => 'required|unique:language_dictionaries,label'
+                ];
+        }
+        
     }
 }

--- a/src/database/migrations/2017_08_28_094840_add_unique_index_to_language_entries_table.php
+++ b/src/database/migrations/2017_08_28_094840_add_unique_index_to_language_entries_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddUniqueIndexToLanguageEntriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $model = new \Build\Core\Eloquent\Models\Language\Entry();
+        $tableName = $model->getTable();
+        
+        // Delete entries that already have more then one entry
+        DB::statement("delete FROM {$tableName}
+            where {$tableName}.id in (
+                select id from (
+                    SELECT count(*) as counter, max(id) as id
+
+                     FROM {$tableName}
+
+                     group by language_id, dictionary_id
+
+                     having counter > 1
+                 ) as invalid_counters
+             )");
+        
+        Schema::table('language_entries', function (Blueprint $table) {
+           $table->unique(['language_id', 'dictionary_id'], 'language_entries_language_id_dictionary_id_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('language_entries', function (Blueprint $table) {
+           $table->dropUnique('language_entries_language_id_dictionary_id_unique');
+        });
+    }
+}


### PR DESCRIPTION
This fixes database issues when (trying to) creating duplicate entries within the language entries.

- Added a button to filter the language view for only "is_active" languages
- Filters the selectable dictionary entries by only showing dictionaries that have not been assigned an entry yet.
- Add a unique requirement for "PUT|PATCH" dictionary requests
- Add a migration for adding the unique index to the table indexes, removing duplicate values from the database first.

Cosmetic fixes
- Changed the style of the success buttons (removed "button--")
