### PR TITLE
added the languages table to the query

### DIFF
--- a/src/Build/Core/Http/Controllers/Languages/IndexController.php
+++ b/src/Build/Core/Http/Controllers/Languages/IndexController.php
@@ -34,8 +34,10 @@ class IndexController extends Controller
         } else {
             $q = Language::byWebsite();
         }
-        
-        $languages = request('all',0) ? $q->get():$q->where('is_active',1)->get();
+
+        $languages = request('all', 0)
+            ? $q->get()
+            : $q->where('languages.is_active', 1)->get();
 
         return entity(LanguageEntity::class, 'index')
             ->setQuery($languages)


### PR DESCRIPTION
Because both languages and websites contain an "is_active" column the query can fail at times. By adding the 'languages' table name this fixes the query error.