### PR TITLE
Hotfix/172577275 unwanted redirect when clicking root menu items

### DIFF
--- a/src/Build/Core/menu.php
+++ b/src/Build/Core/menu.php
@@ -17,15 +17,14 @@ createRightMenu(Menu::get('build.header-right'));
 
 function createLeftMenu($menu)
 {
-    $menu
-        ->add(trans('build.core::menu.structure'))
+    $menu->add(trans('build.core::menu.structure'),null)
         ->nickname('structure');
 
     $menu->structure->add(trans('build.core::menu.structure.websites'), route('admin.websites.index'))
         ->prepend('<i class="fa fa-globe"></i> ');
 
     $menu
-        ->add(trans('build.core::menu.design'))
+        ->add(trans('build.core::menu.design'),null)
         ->nickname('design');
 
     $menu->design->add(trans('build.core::menu.design.colors'), route('admin.colors.index'))
@@ -35,7 +34,7 @@ function createLeftMenu($menu)
         ->prepend('<i class="fa fa-image"></i> ');
 
     $menu
-        ->add(trans('build.core::menu.content'))
+        ->add(trans('build.core::menu.content'),null)
         ->nickname('content');
 
     $menu->content->add(trans('build.core::menu.content.languages'), route('admin.languages.index'))
@@ -44,11 +43,11 @@ function createLeftMenu($menu)
         ->divide();
 
     $menu
-        ->add(trans('build.core::menu.processes'))
+        ->add(trans('build.core::menu.processes'),null)
         ->nickname('processes');
 
     $menu
-        ->add(trans('build.core::menu.admin'))
+        ->add(trans('build.core::menu.admin'),null)
         ->nickname('admin');
 
     $menu->admin->add(trans('build.core::menu.admin.modules'), route('admin.modules.index'));

--- a/src/resources/views/components/navigation.blade.php
+++ b/src/resources/views/components/navigation.blade.php
@@ -5,7 +5,7 @@
 
         @if ($item->hasChildren())
             <li class="header__dropdown">
-                <a href="{!! $item->url() !!}" class="header__dropdown__toggle">
+                <a href="{!! $item->url() ? : '#' !!}" class="header__dropdown__toggle">
                     {!! $item->title !!}
                     <span class="caret"></span>
                 </a>
@@ -16,7 +16,7 @@
             </li>
         @else
             <li>
-                <a href="{{ $item->url() }}">
+                <a href="{{ $item->url() ? : '#' }}">
                     {!! $item->title !!}
                 </a>
             </li>


### PR DESCRIPTION
Fix to prevent menu items linking to the website root (/) when not defining a link in the root menu items.

TIP:
(root)Menu items not containing a link should be added by using
**$menu->add($title, null) or $menu->add($title, [])**

and not 
$menu->add($title)
