### PR TITLE
Added asset fetching from a asset collection

### DIFF
--- a/src/Build/Core/Eloquent/Models/Asset.php
+++ b/src/Build/Core/Eloquent/Models/Asset.php
@@ -13,6 +13,7 @@ namespace Build\Core\Eloquent\Models;
 
 use Build\Core\Eloquent\Model;
 use Build\Core\Eloquent\Traits\Groupable;
+use Build\Core\Support\AssetContainer;
 use Build\Core\Support\ImageFormatter;
 use Build\Core\Support\Mime;
 use Build\Core\Support\System;
@@ -199,6 +200,14 @@ class Asset extends Model
      */
     public static function boot()
     {
+        // Flush and warm the asset container.
+        static::saved(function ($model) {
+            foreach ($model->websites as $website) {
+                AssetContainer::flush($website);
+                AssetContainer::warm($website);
+            }
+        });
+
         static::creating(function (self $model) {
             if (System::is64Bits()) {
                 $uuid = Uuid::uuid1();

--- a/src/Build/Core/Eloquent/Models/Website.php
+++ b/src/Build/Core/Eloquent/Models/Website.php
@@ -40,6 +40,16 @@ class Website extends \Build\Core\Eloquent\Model
     }
 
     /**
+     * The assets relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function assets()
+    {
+        return $this->belongsToMany(Asset::class);
+    }
+
+    /**
      * Scope the query by a given domain.
      *
      * @param  Builder  $query

--- a/src/Build/Core/Support/AssetContainer.php
+++ b/src/Build/Core/Support/AssetContainer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Build\Core\Support;
+
+use Build\Core\Eloquent\Models\Asset;
+use Build\Core\Eloquent\Models\Website;
+
+class AssetContainer
+{
+    /**
+     * The key to create the cache on.
+     *
+     * @var string
+     */
+    static $cacheKey = 'asset-collection.';
+
+    /**
+     * Warm the asset container caches by the given website.
+     *
+     * @param  \Build\Core\Eloquent\Models\Website $website
+     * @return void
+     */
+    public static function warm(Website $website)
+    {
+        $cacheKey = static::$cacheKey.$website->getKey();
+
+        cache()->rememberForever($cacheKey, function () use ($website) {
+            $assets = [];
+
+            foreach ($website->assets as $asset) {
+                $assets[$asset->getKey()] = $asset;
+            }
+
+            return $assets;
+        });
+    }
+
+    /**
+     * Flush to asset container cache for the given website.
+     *
+     * @param \Build\Core\Eloquent\Models\Website $website
+     * @return void
+     */
+    public static function flush(Website $website)
+    {
+        cache()->forget(
+            static::$cacheKey.$website->getKey()
+        );
+    }
+
+    /**
+     * Get the cached asset. If the asset isn't cached we try to
+     * safely fall back to get the asset from the eloquent model.
+     *
+     * @param  int $id
+     * @return \Build\Core\Eloquent\Models\Asset|null
+     */
+    public static function get($id)
+    {
+        $cache = cache()->get(
+            static::$cacheKey.request()->website()->getKey()
+        );
+
+        return array_get($cache, $id) ?: Asset::find($id);
+    }
+}

--- a/src/Build/Core/helpers.php
+++ b/src/Build/Core/helpers.php
@@ -9,10 +9,25 @@
  * file that was distributed with this source code.
  */
 
+use Ramsey\Uuid\Uuid;
+use Build\Core\Support\System;
+use Build\Core\Support\AssetContainer;
 use Build\Content\Support\Facades\Discovery;
 use Build\Core\Eloquent\Models\Language\Entry;
-use Build\Core\Support\System;
-use Ramsey\Uuid\Uuid;
+
+if (! function_exists('asset_get')) {
+    /**
+     * Get the cached asset. If the asset isn't cached we try to
+     * safely fall back to get the asset from the eloquent model.
+     *
+     * @param  int $id
+     * @return \Build\Core\Eloquent\Models\Asset|null
+     */
+    function asset_get($id)
+    {
+        return AssetContainer::get($id);
+    }
+}
 
 if ( ! function_exists('uuid')) {
     /**


### PR DESCRIPTION
When retrieving assets, it's better to use the asset container from now on because it caches all assets by website resulting in not having to create a new query for each separate asset.

use 'asset_get( $asset_id )'